### PR TITLE
fix: do only trim end of line

### DIFF
--- a/src/line_reader.rs
+++ b/src/line_reader.rs
@@ -41,7 +41,8 @@ impl LineReader {
 
         if let Some(eol) = self.get_eol() {
             let line = String::from_utf8_lossy(& self.buffer[0..eol]).into_owned();
-            let line = line.trim();
+            let eol_chars: &[_] = &['\r', '\n'];
+            let line = line.trim_end_matches(eol_chars);
             let pos = eol + 1;
             self.buffer.copy_within(pos.., 0);
             self.pos -= pos;


### PR DESCRIPTION
- do not trim start of line, since this result in invalid end of message detection
- trim only CR (\r) and LF (\n\ characters
- note this might still a little too greedy, since multiple CRs may be removed (but in this case there already something odd with the line)
- also note that no multiple LFs are removed since parsing stops on the this LF